### PR TITLE
Changed shebang in lua scripts to use the more generic /usr/bin/env luajit

### DIFF
--- a/loopit.lua
+++ b/loopit.lua
@@ -1,4 +1,4 @@
-#!/usr/local/bin/luajit
+#!/usr/bin/env luajit
 
 package.path = package.path..";../?.lua;../core/?.lua;"
 

--- a/runonce.lua
+++ b/runonce.lua
@@ -1,4 +1,4 @@
-#!/usr/local/bin/luajit
+#!/usr/bin/env luajit
 
 package.path = package.path..";../?.lua;./core/?.lua;"
 

--- a/testit.lua
+++ b/testit.lua
@@ -1,4 +1,4 @@
-#!/usr/local/bin/luajit
+#!/usr/bin/env luajit
 
 package.path = package.path..";../?.lua;./core/?.lua;"
 

--- a/utils/ovsdb_create.lua
+++ b/utils/ovsdb_create.lua
@@ -1,4 +1,4 @@
---#!/usr/local/bin/luajit 
+--#!/usr/bin/env luajit 
 
 package.path = package.path..";../?.lua"
 


### PR DESCRIPTION
Using "/usr/bin/env luajit" should be more generic and more platform independant. Using env will ensure that luajit will be used as long as it is in path. This way the commands work directly on Debian, Ubuntu and ArchLinux (which install luajit to /usr/bin/luajit)

There is some discussion about env vs. absolute paths. You might check it out here:
https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my

In case using an absolute path was on purpose, feel free to comment or discard this pull request.

Cheers,

Matthias
